### PR TITLE
Feat/text input

### DIFF
--- a/packages/block/__tests__/block.test.ts
+++ b/packages/block/__tests__/block.test.ts
@@ -4,7 +4,7 @@ describe('@artifak/block', () => {
   describe('createBlocks - generates Block React components based on styles object argument provided', () => {
     it('should return the base Typography system component when provided with an invalid argument', () => {
       const expected = {};
-      expect(createBlocks({} as any, {} as any)).toEqual(expected);
+      expect(createBlocks({} as any, {} as any)).toHaveProperty('Base');
       expect(createBlocks(null as any, null as any)).toEqual(expected);
       expect(createBlocks(false as any, false as any)).toEqual(expected);
       expect(createBlocks(0 as any, 0 as any)).toEqual(expected);

--- a/packages/block/src/createBlocks.tsx
+++ b/packages/block/src/createBlocks.tsx
@@ -14,7 +14,7 @@ export function createBlocks<
   Element = HTMLDivElement
 >(
   base: StyledComponentConfig<Props, ThemeType, Element>,
-  settings: Settings
+  settings: Settings<Element>
 ): GenericRecord<Config, React.FC<Props & Variant<ThemeType>>> {
   return createComponents<Config, ThemeType, Props, Element>(base, settings);
 }

--- a/packages/block/src/createBlocks.tsx
+++ b/packages/block/src/createBlocks.tsx
@@ -1,9 +1,8 @@
 import {
   createComponents,
-  GenericRecord,
+  ComponentsRecord,
   Settings,
-  StyledComponentConfig,
-  Variant
+  StyledComponentConfig
 } from '@artifak/component-generator';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -15,6 +14,6 @@ export function createBlocks<
 >(
   base: StyledComponentConfig<Props, ThemeType, Element>,
   settings: Settings<Element>
-): GenericRecord<Config, React.FC<Props & Variant<ThemeType>>> {
+): ComponentsRecord<Config, Props, ThemeType> {
   return createComponents<Config, ThemeType, Props, Element>(base, settings);
 }

--- a/packages/component-generator/__tests__/createStyledComponent.test.ts
+++ b/packages/component-generator/__tests__/createStyledComponent.test.ts
@@ -1,5 +1,5 @@
 import { system } from 'styled-system';
-import { createStyledComponent } from '../src';
+import { createStyledComponent, extractStylePseudos } from '../src';
 
 describe('createStyledComponent - creates a styled component with params of styles, styleProps, attrs and element', () => {
   it('should return a styled component with default config when no arguments are provided', () => {
@@ -24,5 +24,35 @@ describe('createStyledComponent - creates a styled component with params of styl
     });
 
     expect(resultingStyledComponent).toBeDefined();
+  });
+});
+
+describe('extractStylePseudos', () => {
+  it('should return an empty object if styles arg is invalid', () => {
+    expect(extractStylePseudos()).toEqual({});
+  });
+
+  it('should return pseudo styles from styles object', () => {
+    const styles = {
+      display: 'block',
+
+      '&:hover': {
+        color: 'red'
+      },
+
+      '&::-webkit-input-placeholder': {
+        color: 'hotpink'
+      }
+    };
+
+    expect(extractStylePseudos(styles)).toEqual({
+      '&:hover': {
+        color: 'red'
+      },
+
+      '&::-webkit-input-placeholder': {
+        color: 'hotpink'
+      }
+    });
   });
 });

--- a/packages/component-generator/index.stories.tsx
+++ b/packages/component-generator/index.stories.tsx
@@ -55,6 +55,25 @@ export function BasicUsage() {
   );
 }
 
+const {
+  Container: BasicContainer,
+  FlexContainer: BasicFlexContainer,
+  UnpaddedContainer: BasicUnpaddedContainer
+} = createComponents<typeof containers.components>(
+  Basic,
+  containers.components
+);
+
+export function UsageWithSCbase() {
+  return (
+    <>
+      <BasicContainer>Default Container</BasicContainer>
+      <BasicFlexContainer>Flex Container</BasicFlexContainer>
+      <BasicUnpaddedContainer>Unpadded Container</BasicUnpaddedContainer>
+    </>
+  );
+}
+
 export default {
   title: 'Generator'
 };

--- a/packages/component-generator/package.json
+++ b/packages/component-generator/package.json
@@ -59,7 +59,8 @@
     "styled-components": ">=5.2.1"
   },
   "dependencies": {
-    "lodash.isempty": "^4.4.0"
+    "lodash.isempty": "^4.4.0",
+    "lodash.isplainobject": "^4.0.6"
   },
   "resolutions": {
     "react": ">=17.0.1"

--- a/packages/component-generator/src/index.tsx
+++ b/packages/component-generator/src/index.tsx
@@ -1,10 +1,13 @@
 export { createComponents } from './createComponents';
-export { createStyledComponent } from './createStyledComponent';
+export {
+  createStyledComponent,
+  extractStylePseudos
+} from './createStyledComponent';
 export {
   Attrs,
   BaseProps,
   BaseComponentProps,
-  GenericRecord,
+  ComponentsRecord,
   Settings,
   StyledComponentConfig,
   Variant

--- a/packages/component-generator/src/typings.ts
+++ b/packages/component-generator/src/typings.ts
@@ -1,3 +1,4 @@
+import { AllHTMLAttributes } from 'react';
 import * as CSS from 'csstype';
 import { ThemedStyledFunction, ThemedStyledProps } from 'styled-components';
 import { styleFn, Scale } from 'styled-system';
@@ -43,7 +44,7 @@ export type StyledComponentConfig<
   ThemeType = void
 > = {
   styles?: StyledSystemCSSObject;
-  attrs?: Attrs<Props, Attributes, ThemeType>;
+  attrs?: Attributes;
   styleProps?: styleFn[];
   element?: keyof JSX.IntrinsicElements;
   component?: ThemedStyledFunction<
@@ -58,10 +59,15 @@ export type CSSObjectWithScale = CSS.Properties<string | number | Scale>;
 export type CSSPseudos = { [K in CSS.Pseudos]?: CSSObjectWithScale };
 export type StyledSystemCSSObject = CSSObjectWithScale & CSSPseudos;
 
-export type GenericRecord<Dict, Type> = {
-  [key in keyof Dict]: Type;
+export type ComponentsRecord<Dict, Props, ThemeType> = {
+  [key in keyof Dict | 'Base']: React.FC<
+    Props & BaseProps<ThemeType> & Variant<ThemeType>
+  >;
 };
 
-export type Settings = {
-  [key: string]: StyledSystemCSSObject & { as?: string };
+export type Settings<Element = HTMLDivElement> = {
+  [key: string]: StyledSystemCSSObject & {
+    as?: string;
+    attrs?: AllHTMLAttributes<Element>;
+  };
 };

--- a/packages/text-input/README.md
+++ b/packages/text-input/README.md
@@ -1,0 +1,11 @@
+# `@artifak/text-input`
+
+> TODO: description
+
+## Usage
+
+```
+const textInput = require('@artifak/text-input');
+
+// TODO: DEMONSTRATE API
+```

--- a/packages/text-input/__tests__/createTextInputs.test.tsx
+++ b/packages/text-input/__tests__/createTextInputs.test.tsx
@@ -1,0 +1,39 @@
+import { createTextInputs } from '../src';
+
+describe('createTypography - generates typography React components based on styles object argument provided', () => {
+  it('should return the base Typography system component when provided with an invalid argument', () => {
+    expect(createTextInputs({} as any, {} as any)).toHaveProperty('Base');
+    expect(createTextInputs(null as any, null as any)).toHaveProperty('Base');
+    expect(createTextInputs(false as any, false as any)).toHaveProperty('Base');
+    expect(createTextInputs(0 as any, 0 as any)).toHaveProperty('Base');
+    expect(createTextInputs(void 0 as any, void 0 as any)).toHaveProperty(
+      'Base'
+    );
+  });
+
+  it('should create React components', () => {
+    const inputs = {
+      base: {
+        styles: {
+          width: '100%',
+          border: '1px solid black',
+          padding: ['1em']
+        }
+      },
+
+      components: {
+        InputSearch: {
+          maxWidth: '300px',
+          attrs: { type: 'search' }
+        },
+
+        InputUrl: {
+          display: 'block',
+          attrs: { type: 'url' }
+        }
+      }
+    };
+
+    expect(createTextInputs(inputs.base, inputs.components)).toBeDefined();
+  });
+});

--- a/packages/text-input/index.stories.tsx
+++ b/packages/text-input/index.stories.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { createTextInputs } from './src';
+
+const inputs = {
+  base: {
+    styles: {
+      width: '100%',
+      border: '1px solid black',
+      padding: ['1em']
+    }
+  },
+
+  components: {
+    InputSearch: {
+      maxWidth: '300px',
+      attrs: { type: 'search' }
+    },
+
+    InputUrl: {
+      display: 'block',
+      attrs: { type: 'url' }
+    }
+  }
+};
+
+const { Base: InputText, InputSearch, InputUrl } = createTextInputs<
+  typeof inputs.components
+>(inputs.base, inputs.components);
+
+export function BasicUsage() {
+  return (
+    <>
+      <InputText />
+      <InputSearch />
+      <InputUrl />
+    </>
+  );
+}
+
+export default {
+  title: 'TextInput'
+};

--- a/packages/text-input/package.json
+++ b/packages/text-input/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@artifak/text-input",
+  "version": "1.0.0",
+  "description": "Text input components which comprises typeos of text, tel, url, email, search and password.",
+  "keywords": [],
+  "author": "Julian Low",
+  "license": "ISC",
+  "main": "dist/text-input.cjs.js",
+  "module": "dist/text-input.esm.js",
+  "src": "src/index.tsx",
+  "types": "dist/src/index.d.ts",
+  "directories": {
+    "src": "src",
+    "test": "__tests__"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/heyjul3s/artifak.git"
+  },
+  "scripts": {
+    "build": "rimraf dist && builder",
+    "test": "echo \"Error: run tests from root\" && exit 1"
+  },
+  "bugs": {
+    "url": "https://github.com/heyjul3s/artifak/issues"
+  },
+  "homepage": "https://github.com/heyjul3s/artifak#readme",
+  "devDependencies": {
+    "@artifak/bundler": "^1.1.3",
+    "@types/react": "^17.0.0",
+    "@types/react-dom": "^17.0.0",
+    "@types/styled-components": "^5.1.7",
+    "@types/styled-system": "^5.1.10",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
+    "styled-components": "^5.2.1",
+    "styled-system": "^5.1.5"
+  },
+  "dependencies": {
+    "@artifak/component-generator": "^1.1.4"
+  }
+}

--- a/packages/text-input/src/createTextInputs.tsx
+++ b/packages/text-input/src/createTextInputs.tsx
@@ -1,0 +1,27 @@
+import React, { AllHTMLAttributes } from 'react';
+import {
+  createComponents,
+  Settings,
+  StyledComponentConfig,
+  Variant
+} from '@artifak/component-generator';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export function createTextInputs<
+  Config,
+  Props = any,
+  ThemeType = any,
+  Element = HTMLInputElement
+>(
+  base: StyledComponentConfig<Props, ThemeType, AllHTMLAttributes<Element>>,
+  settings: Settings<Element>
+): { [key in keyof Config | 'Base']: React.FC<Props & Variant<ThemeType>> } {
+  return createComponents<Config, ThemeType, Props, Element>(
+    {
+      element: 'input',
+      attrs: { type: 'text' },
+      ...base
+    },
+    settings
+  );
+}

--- a/packages/text-input/src/index.tsx
+++ b/packages/text-input/src/index.tsx
@@ -1,0 +1,1 @@
+export { createTextInputs } from './createTextInputs';

--- a/packages/text-input/tsconfig.json
+++ b/packages/text-input/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "allowSyntheticDefaultImports": true,
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "references": [],
+  "include": ["src"]
+}

--- a/packages/typography/__tests__/createTypography.test.ts
+++ b/packages/typography/__tests__/createTypography.test.ts
@@ -1,5 +1,4 @@
-import { position } from 'styled-system';
-import { createTypography, getStyleProps, fontWeight } from '../src';
+import { createTypography } from '../src';
 
 describe('createTypography - generates typography React components based on styles object argument provided', () => {
   it('should return the base Typography system component when provided with an invalid argument', () => {

--- a/packages/typography/src/createTypography.ts
+++ b/packages/typography/src/createTypography.ts
@@ -1,9 +1,8 @@
 import {
-  GenericRecord,
+  ComponentsRecord,
   createComponents,
   Settings,
-  StyledComponentConfig,
-  Variant
+  StyledComponentConfig
 } from '@artifak/component-generator';
 import { styleFn } from 'styled-system';
 import { TypographyBaseProps } from './typings';
@@ -18,10 +17,7 @@ export function createTypography<
 >(
   base: StyledComponentConfig<Props, ThemeType, Element>,
   settings: Settings<Element>
-): GenericRecord<
-  Config,
-  React.FC<Props & TypographyBaseProps & Variant<ThemeType>>
-> {
+): ComponentsRecord<Config, Props & TypographyBaseProps, ThemeType> {
   const { styleProps } = getStyleProps(base);
 
   return createComponents<

--- a/packages/typography/src/createTypography.ts
+++ b/packages/typography/src/createTypography.ts
@@ -17,7 +17,7 @@ export function createTypography<
   Element = HTMLDivElement
 >(
   base: StyledComponentConfig<Props, ThemeType, Element>,
-  settings: Settings
+  settings: Settings<Element>
 ): GenericRecord<
   Config,
   React.FC<Props & TypographyBaseProps & Variant<ThemeType>>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12209,7 +12209,7 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@>=17.0.1, react-dom@^17.0.1:
+react-dom@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.1.tgz#1de2560474ec9f0e334285662ede52dbc5426fc6"
   integrity sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==


### PR DESCRIPTION
Refactor Generator and TextInput
- Generator update to retain functionality to accept SC as base for createComponents
- createStyledComponents now accepts pseudo CSS
- update createBlocks and createTypography to new Settings type
- add new TextInput generator
